### PR TITLE
Ensure _row_num is Integer

### DIFF
--- a/simple_smartsheet/models/sheet.py
+++ b/simple_smartsheet/models/sheet.py
@@ -367,4 +367,6 @@ class Sheet(_SheetBase[Row, Column]):
         import pandas as pd
 
         df = pd.DataFrame([row.as_series() for row in self.rows])
+        df._row_num = df._row_num.astype("int64")
+        
         return df

--- a/simple_smartsheet/models/sheet.py
+++ b/simple_smartsheet/models/sheet.py
@@ -368,5 +368,4 @@ class Sheet(_SheetBase[Row, Column]):
 
         df = pd.DataFrame([row.as_series() for row in self.rows])
         df._row_num = df._row_num.astype("int64")
-        
         return df


### PR DESCRIPTION
Under certain circumstances where a sheet has a completely empty row between rows with data, the data type for `_row_num` becomes float64