### PR TITLE
Updated register_structure_hook calls

### DIFF
--- a/simple_smartsheet/models/base.py
+++ b/simple_smartsheet/models/base.py
@@ -26,9 +26,9 @@ from simple_smartsheet.types import IndexesType
 logger = logging.getLogger(__name__)
 
 converter = Converter()  # type: ignore
-converter.register_structure_hook(datetime, lambda ts, _: ts)
-converter.register_structure_hook(IndexesType, lambda x, _: x)
-converter.register_structure_hook(Union[float, str, datetime, None], lambda ts, _: ts)
+converter.register_structure_hook_func(datetime, lambda ts, _: ts)
+converter.register_structure_hook_func(IndexesType, lambda x, _: x)
+converter.register_structure_hook_func(Union[float, str, datetime, None], lambda ts, _: ts)
 
 
 class Schema(marshmallow.Schema):


### PR DESCRIPTION
Updated register_structure_hook calls per cattrs issue 206 recommendation.  This fixes issue #35 and allows simple-smarthsheet to work with python3.9+.  